### PR TITLE
Make plugin compatible with Windows

### DIFF
--- a/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
@@ -42,10 +42,19 @@ public class ScsProjectGenerator extends ProjectGenerator {
             final OutputStream os = new FileOutputStream(tempOutputFile1);
             MavenModelUtils.addDockerPlugin(request.getArtifactId(), request.getVersion(), dockerHubOrg, is, os);
 
-            MavenModelUtils.addSurefirePlugin(new FileInputStream(tempOutputFile1), new FileOutputStream(tempOutputFile2));
+            FileInputStream is1 = new FileInputStream(tempOutputFile1);
+            FileOutputStream os1 = new FileOutputStream(tempOutputFile2);
+
+            MavenModelUtils.addSurefirePlugin(is1, os1);
+
+            is.close();
+            is1.close();
+            os.close();
+            os1.close();
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
+
 
         inputFile.delete();
         tempOutputFile2.renameTo(inputFile);

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -1,5 +1,13 @@
 package org.springframework.cloud.stream.app.plugin.utils;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
@@ -7,8 +15,6 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-
-import java.io.*;
 
 /**
  * @author Soby Chacko
@@ -78,6 +84,7 @@ public class MavenModelUtils {
         final MavenXpp3Writer writer = new MavenXpp3Writer();
         OutputStreamWriter w = new OutputStreamWriter(os, "utf-8");
         writer.write(w, model);
+        w.close();
     }
 
     private static Model getModel(File pom) throws IOException, XmlPullParserException {

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/utils/SpringCloudStreamPluginUtils.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/utils/SpringCloudStreamPluginUtils.java
@@ -16,14 +16,14 @@
 
 package org.springframework.cloud.stream.app.plugin.utils;
 
-import org.apache.commons.io.FileUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
 
 /**
  * @author Soby Chacko
@@ -56,9 +56,7 @@ public class SpringCloudStreamPluginUtils {
     }
 
     public static void ignoreUnitTestGeneratedByInitializer(String generatedAppHome) throws IOException {
-        String testDir = String.format("%s/%s", generatedAppHome, "src/test/java");
-
-        Collection<File> files = FileUtils.listFiles(new File(testDir), null, true);
+        Collection<File> files = FileUtils.listFiles(new File(generatedAppHome, "src/main/java"), null, true);
         Optional<File> first = files.stream()
                 .filter(f -> f.getName().endsWith("ApplicationTests.java"))
                 .findFirst();
@@ -91,9 +89,7 @@ public class SpringCloudStreamPluginUtils {
     }
 
     public static void addExtraTestConfig(String generatedAppHome, String clazzInfo) throws IOException {
-        String testDir = String.format("%s/%s", generatedAppHome, "src/test/java");
-
-        Collection<File> files = FileUtils.listFiles(new File(testDir), null, true);
+        Collection<File> files = FileUtils.listFiles(new File(generatedAppHome, "src/main/java"), null, true);
         Optional<File> first = files.stream()
                 .filter(f -> f.getName().endsWith("ApplicationTests.java"))
                 .findFirst();
@@ -115,9 +111,7 @@ public class SpringCloudStreamPluginUtils {
     }
 
     public static void addAutoConfigImport(String generatedAppHome, String autoConfigClazz) throws IOException {
-        String srcDir = String.format("%s/%s", generatedAppHome, "src/main/java");
-
-        Collection<File> files = FileUtils.listFiles(new File(srcDir), null, true);
+        Collection<File> files = FileUtils.listFiles(new File(generatedAppHome, "src/main/java"), null, true);
         Optional<File> first = files.stream()
                 .filter(f -> f.getName().endsWith("Application.java"))
                 .findFirst();

--- a/src/test/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojoTest.java
+++ b/src/test/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojoTest.java
@@ -16,16 +16,9 @@
 
 package org.springframework.cloud.stream.app.plugin;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.springframework.util.ReflectionUtils;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -40,9 +33,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Soby Chacko
@@ -106,7 +106,7 @@ public class SpringCloudStreamAppMojoTest {
 
     @Test
     public void testProjectCreatedIntoGeneratedProjectHome() throws Exception {
-        String projectHome = "/tmp/apps";
+        String projectHome = "./target/apps";
         Field generatedProjectHome = mojoClazz.getDeclaredField("generatedProjectHome");
         generatedProjectHome.setAccessible(true);
         ReflectionUtils.setField(generatedProjectHome, springCloudStreamAppMojo, projectHome);
@@ -122,10 +122,6 @@ public class SpringCloudStreamAppMojoTest {
 
         assertGeneratedPomXml(path);
 
-        //cleanup
-        File projectRoot = new File(projectHome);
-        FileUtils.cleanDirectory(projectRoot);
-        FileUtils.deleteDirectory(projectRoot);
     }
 
     private void assertGeneratedPomXml(Path path) throws Exception {
@@ -170,5 +166,7 @@ public class SpringCloudStreamAppMojoTest {
                 equalTo(1L));
 
         assertThat(pomModel.getRepositories().size(), equalTo(2));
+
+        is.close();
     }
 }


### PR DESCRIPTION
The main problem on Windows that all `InputStream`/`OutputStream` must be closed before deleting/renaming files
Also `Files.move` doesn't work on Windows somehow.
Replace it to the `FileUtils.copyDirectory`.