### PR TITLE
Docker entrypoint using shell style to take the JAVA_OPTS

### DIFF
--- a/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
@@ -37,7 +37,10 @@ public class ScsProjectGenerator extends ProjectGenerator {
 
     @Override
     protected File doGenerateProjectStructure(ProjectRequest request) {
+        return doGenerateProjectStructure(request, MavenModelUtils.ENTRYPOINT_TYPE_EXEC);
+    }
 
+    protected File doGenerateProjectStructure(ProjectRequest request, String entrypointType) {
         final File rootDir = super.doGenerateProjectStructure(request);
 
         final File dir = new File(rootDir, request.getBaseDir());
@@ -53,7 +56,7 @@ public class ScsProjectGenerator extends ProjectGenerator {
         try {
             final InputStream is = new FileInputStream(inputFile);
             final OutputStream os = new FileOutputStream(tempOutputFile1);
-            MavenModelUtils.addDockerPlugin(request.getArtifactId(), request.getVersion(), dockerHubOrg, is, os);
+            MavenModelUtils.addDockerPlugin(request.getArtifactId(), request.getVersion(), dockerHubOrg, is, os, entrypointType);
 
             FileInputStream is1 = new FileInputStream(tempOutputFile1);
             FileOutputStream os1 = new FileOutputStream(tempOutputFile2);
@@ -87,7 +90,6 @@ public class ScsProjectGenerator extends ProjectGenerator {
         tempOutputFile2.delete();
 
         return rootDir;
-
     }
 
     public void setDockerHubOrg(String dockerHubOrg) {

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -56,6 +56,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.util.CollectionUtils;
 
 import static java.util.stream.Collectors.toList;
+import static org.springframework.cloud.stream.app.plugin.utils.MavenModelUtils.ENTRYPOINT_TYPE_EXEC;
+import static org.springframework.cloud.stream.app.plugin.utils.MavenModelUtils.ENTRYPOINT_TYPE_SHELL;
 
 /**
  * @author Soby Chacko
@@ -87,6 +89,9 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 	private String generatedProjectVersion;
 
 	@Parameter
+	private String entrypointType = ENTRYPOINT_TYPE_EXEC;
+
+	@Parameter
 	private String applicationType;
 
 	@Parameter
@@ -110,6 +115,13 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 	private ScsProjectGenerator projectGenerator = new ScsProjectGenerator();
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (!entrypointType.equals(ENTRYPOINT_TYPE_EXEC)
+				&& !entrypointType.equals(ENTRYPOINT_TYPE_SHELL)) {
+			throw new MojoFailureException(
+					String.format(
+							"Your entrypointType: %s is wrong, only 'exec' or 'shell' supported", entrypointType));
+		}
+		getLog().info("Generating apps with entrypointType: " + entrypointType);
 
 		projectGenerator.setDockerHubOrg("springcloud" + applicationType);
 		projectGenerator.setBomsWithHigherPrecedence(bomsWithHigherPrecedence);
@@ -250,7 +262,7 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 		ProjectRequest projectRequest = initializrDelegate.getProjectRequest(appArtifactId, getApplicationGroupId(applicationType),
 				getDescription(appArtifactId), getPackageName(appArtifactId),
 				generatedProjectVersion, artifactNames);
-		File project = projectGenerator.doGenerateProjectStructure(projectRequest);
+		File project = projectGenerator.doGenerateProjectStructure(projectRequest, this.entrypointType);
 
 		File generatedProjectHome = StringUtils.isNotEmpty(this.generatedProjectHome) ?
 				new File(this.generatedProjectHome) :


### PR DESCRIPTION
  - support exec and shell entrypoint type
  - add property <entrypointType> to mojo, value can be 'shell' or 'exec'
  - shell style entrypoint can take command arguments