### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/Bom.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/Bom.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMetadataBuilder.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMetadataBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -68,7 +68,7 @@ public class MavenModelUtils {
             model.setUrl("http://spring.io/spring-cloud");
             License license = new License();
             license.setName("Apache License, Version 2.0");
-            license.setUrl("http://www.apache.org/licenses/LICENSE-2.0");
+            license.setUrl("https://www.apache.org/licenses/LICENSE-2.0");
             license.setComments("Copyright 2014-2015 the original author or authors.\n" +
                     "\n" +
                     "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +

--- a/src/main/java/org/springframework/cloud/stream/app/plugin/utils/SpringCloudStreamPluginUtils.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/utils/SpringCloudStreamPluginUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ public class SpringCloudStreamPluginUtils {
             " * you may not use this file except in compliance with the License.\n" +
             " * You may obtain a copy of the License at\n" +
             " *\n" +
-            " *      http://www.apache.org/licenses/LICENSE-2.0\n" +
+            " *      https://www.apache.org/licenses/LICENSE-2.0\n" +
             " *\n" +
             " * Unless required by applicable law or agreed to in writing, software\n" +
             " * distributed under the License is distributed on an \"AS IS\" BASIS,\n" +

--- a/src/test/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojoTest.java
+++ b/src/test/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 8 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).