### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -65,7 +65,7 @@ public class MavenModelUtils {
             model.setVersion(version);
             model.setName("Apps Container");
             model.setDescription("Container project for generated apps");
-            model.setUrl("http://spring.io/spring-cloud");
+            model.setUrl("https://spring.io/spring-cloud");
             License license = new License();
             license.setName("Apache License, Version 2.0");
             license.setUrl("http://www.apache.org/licenses/LICENSE-2.0");
@@ -98,7 +98,7 @@ public class MavenModelUtils {
             developer.setName("Soby Chacko");
             developer.setEmail("schacko at pivotal.io");
             developer.setOrganization("Pivotal Software, Inc.");
-            developer.setOrganizationUrl("http://www.spring.io");
+            developer.setOrganizationUrl("https://www.spring.io");
             List<String> roles = new ArrayList<>();
             roles.add("developer");
             developer.setRoles(roles);


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* [ ] http://spring.io/spring-cloud with 1 occurrences migrated to:  
  https://spring.io/spring-cloud ([https](https://spring.io/spring-cloud) result 302).